### PR TITLE
Modify test case to cover more datetime issues in TVP issue #390

### DIFF
--- a/Insight.Database.Providers.Default/SqlDataRecordAdapter.cs
+++ b/Insight.Database.Providers.Default/SqlDataRecordAdapter.cs
@@ -44,19 +44,16 @@ namespace Insight.Database.Providers.Default
 		private ObjectReader _objectReader;
 		private IEnumerable _list;
 		private SqlMetaData[] _metadata;
-		private bool _supportsDateTime2;
 
 		/// <summary>
 		/// Constucts an instance of the SqlDataRecordAdapter class.
 		/// </summary>
 		/// <param name="objectReader">The ObjectReader to use to extract properties from the object.</param>
 		/// <param name="list">The list of objects to read.</param>
-		/// <param name="supportsDateTime2">True if the server supports DateTime2.</param>
-		public SqlDataRecordAdapter(ObjectReader objectReader, IEnumerable list, bool supportsDateTime2)
+		public SqlDataRecordAdapter(ObjectReader objectReader, IEnumerable list)
 		{
 			_objectReader = objectReader;
 			_list = list;
-			_supportsDateTime2 = supportsDateTime2;
 
 			_metadata = objectReader.Columns.Select(c => new SqlMetaData(
 				c.Name,
@@ -112,9 +109,9 @@ namespace Insight.Database.Providers.Default
 				switch (dataTypeName.ToLowerInvariant())
 				{
 					case "date":
+						return SqlDbType.Date;
 					case "datetime":
-						return _supportsDateTime2 ? SqlDbType.DateTime2 : SqlDbType.DateTime;
-
+						return SqlDbType.DateTime;
 					case "datetime2":
 						return SqlDbType.DateTime2;
 				}

--- a/Insight.Database.Providers.Default/SqlInsightDbProvider.cs
+++ b/Insight.Database.Providers.Default/SqlInsightDbProvider.cs
@@ -231,7 +231,7 @@ namespace Insight.Database
                     CommandBehavior.Default));
 
             if (!isEmpty)
-                parameter.Value = new SqlDataRecordAdapter(objectReader, list, SupportsDateTime2(command));
+                parameter.Value = new SqlDataRecordAdapter(objectReader, list);
         }
 
         /// <summary>

--- a/Insight.Database.Providers.MsSqlClient/SqlDataRecordAdapter.cs
+++ b/Insight.Database.Providers.MsSqlClient/SqlDataRecordAdapter.cs
@@ -44,19 +44,16 @@ namespace Insight.Database.Providers.MsSqlClient
 		private ObjectReader _objectReader;
 		private IEnumerable _list;
 		private SqlMetaData[] _metadata;
-		private bool _supportsDateTime2;
 
 		/// <summary>
 		/// Constucts an instance of the SqlDataRecordAdapter class.
 		/// </summary>
 		/// <param name="objectReader">The ObjectReader to use to extract properties from the object.</param>
 		/// <param name="list">The list of objects to read.</param>
-		/// <param name="supportsDateTime2">True if the server supports DateTime2.</param>
-		public SqlDataRecordAdapter(ObjectReader objectReader, IEnumerable list, bool supportsDateTime2)
+		public SqlDataRecordAdapter(ObjectReader objectReader, IEnumerable list)
 		{
 			_objectReader = objectReader;
 			_list = list;
-			_supportsDateTime2 = supportsDateTime2;
 
 			_metadata = objectReader.Columns.Select(c => new SqlMetaData(
 				c.Name,
@@ -112,9 +109,9 @@ namespace Insight.Database.Providers.MsSqlClient
 				switch (dataTypeName.ToLowerInvariant())
 				{
 					case "date":
+						return SqlDbType.Date;
 					case "datetime":
-						return _supportsDateTime2 ? SqlDbType.DateTime2 : SqlDbType.DateTime;
-
+						return SqlDbType.DateTime;
 					case "datetime2":
 						return SqlDbType.DateTime2;
 				}

--- a/Insight.Database.Providers.MsSqlClient/SqlInsightDbProvider.cs
+++ b/Insight.Database.Providers.MsSqlClient/SqlInsightDbProvider.cs
@@ -222,7 +222,7 @@ namespace Insight.Database.Providers.MsSqlClient
                     CommandBehavior.Default));
 
             if (!isEmpty)
-                parameter.Value = new SqlDataRecordAdapter(objectReader, list, SupportsDateTime2(command));
+                parameter.Value = new SqlDataRecordAdapter(objectReader, list);
         }
 
         /// <summary>

--- a/Insight.Tests/BaseTest.cs
+++ b/Insight.Tests/BaseTest.cs
@@ -27,6 +27,8 @@ namespace Insight.Tests
 			var testHost = Environment.GetEnvironmentVariable("INSIGHT_TEST_HOST");
 			if (testHost != null)
 				TestHost = Regex.Match(testHost, @"\d+\.\d+\.\d+\.\d+").Value;
+			if (string.IsNullOrEmpty(TestHost)  && !string.IsNullOrEmpty(testHost))
+				TestHost = testHost;
 
 			Password = Environment.GetEnvironmentVariable("INSIGHT_TEST_PASSWORD");
 

--- a/Insight.Tests/TableValuedParametersTests.cs
+++ b/Insight.Tests/TableValuedParametersTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Data;
+using System.Data.SqlTypes;
 using System.Linq;
 using Insight.Database;
 using NUnit.Framework;
@@ -137,7 +138,7 @@ namespace Insight.Tests
 		[SetUp]
 		public void SetUp()
 		{
-			Connection().ExecuteSql("create type SimpleDateTable as table (Value date)");
+			Connection().ExecuteSql("create type SimpleDateTable as table (Value date, Value2 datetime not null, Value3 datetime null, Value4 datetime2)");
 		}
 
 		[TearDown]
@@ -169,9 +170,17 @@ namespace Insight.Tests
 		public class SimpleDate
 		{
 			public SimpleDate(DateTime value)
-				=> Value = value;
+			{
+				Value = value;
+				Value2 = default == value ? (DateTime)SqlDateTime.MinValue : value;
+				Value3 = default != value ? (DateTime?)value : null;
+				Value4 = value;
+			}
 
 			public DateTime Value { get; }
+			public DateTime Value2 { get; }
+			public DateTime? Value3 { get; }
+			public DateTime Value4 { get; }
 		}
 	}
 	#endregion


### PR DESCRIPTION
## Description
fixes #390

## Checklist
Please make sure your pull request fulfills the following requirements:

- [x] Tests for any changes have been added (for bug fixes / features).
- [ ] Docs have been added / updated (for bug fixes / features).

## Type
This pull request includes what type of changes?
<!-- please check the one that applies using an "x" -->

- [x] Bug.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Documentation content changes.
- [ ] Other (please describe below).


## Breaking Changes
Does this pull request introduce any breaking changes?
<!-- please check the one that applies using an "x" -->

- [ ] Yes
- [?] No

### Any other comment
<!-- Provide additional relevant info here. -->
in SqlInsightDbProvider.FixupParameter I see where dbtype is updated to datetime2 if the db supports datetime2.
I think based on the comment above that code and the bugs around datetime2 it probably should be reversed and only change the dbtype if the type is datetime2 and it is not supported (although I am curious why that would happen) it seems a much safer change to only back down if needed vs always converting up when the smaller datatypes are still completely valid in newer sql versions.

If you agree I'll be happy to modify this pr with that change also.  GetSqlDType could also be adjusted to similar logic and then check for if not supported never return datetime2. 
